### PR TITLE
setup tooltip close on clickaway

### DIFF
--- a/assets/styles/global/_tooltip.scss
+++ b/assets/styles/global/_tooltip.scss
@@ -81,7 +81,6 @@
 
   &.popover {
     $color: var(--tooltip-bg);
-    display:inline;
 
     .popover-inner {
       background: $color;
@@ -107,4 +106,8 @@
     opacity: 1;
     transition: opacity .15s;
   }
+}
+
+.v-popover {
+  display: inline;
 }

--- a/assets/styles/global/_tooltip.scss
+++ b/assets/styles/global/_tooltip.scss
@@ -80,11 +80,12 @@
   }
 
   &.popover {
-    $color: #f9f9f9;
+    $color: var(--tooltip-bg);
+    display:inline;
 
     .popover-inner {
       background: $color;
-      color: --modal-overlay-bg;
+      color: var(--tooltip-text);
       padding: 10px;
       border-radius: 5px;
       box-shadow: 0 5px 30px rgba(var(--modal-overlay-bg), .1);

--- a/pages/auth/setup.vue
+++ b/pages/auth/setup.vue
@@ -15,15 +15,6 @@ export default {
   },
 
   computed: {
-    telemetryTooltip() {
-      return `Rancher Labs would like to collect a bit of anonymized information<br/>
-      about the configuration of your installation to help make Rio better.<br/></br>
-      Your data will not be shared with anyone else, and no information about<br/>
-      what specific resources or endpoints you are deploying is included.<br/>
-      Once enabled you can view exactly what data will be sent at <code>/v1-telemetry</code>.<br/><br/>
-      <a href="https://rancher.com/docs/rancher/v2.x/en/faq/telemetry/" target="_blank">More Info</a>`;
-    },
-
     passwordSubmitDisabled() {
       if ( !this.password || this.password !== this.confirm ) {
         return true;
@@ -375,7 +366,15 @@ export default {
                   <input v-model="telemetry" type="checkbox" />
                   Allow collection of anonymous statistics to help us improve Rio
                 </label>
-                <i v-tooltip="{content: telemetryTooltip, placement: 'right', trigger: 'click'}" class="icon icon-info" />
+                <v-popover placement="right">
+                  <i class="icon icon-info" />
+                  <span slot="popover">Rancher Labs would like to collect a bit of anonymized information<br />
+                    about the configuration of your installation to help make Rio better.<br /></br>
+                    Your data will not be shared with anyone else, and no information about<br />
+                    what specific resources or endpoints you are deploying is included.<br />
+                    Once enabled you can view exactly what data will be sent at <code>/v1-telemetry</code>.<br /><br />
+                    <a href="https://rancher.com/docs/rancher/v2.x/en/faq/telemetry/" target="_blank">More Info</a></span>
+                </v-popover>
               </div>
             </div>
           </div>


### PR DESCRIPTION
#74 - click-to-open tooltip in auth setup step-2 swapped out for a popover that closes on click away