### PR TITLE
opening action menu no longer shifts up page footer

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -194,7 +194,7 @@ export default {
       "logo user main"
       "nav  nav  main";
     grid-template-columns: 190px 60px auto;
-    grid-template-rows: $header-height auto;
+    grid-template-rows: $header-height auto 0px;
 
     .logo {
       grid-area: logo;


### PR DESCRIPTION
Fixes this:
![Screen Shot 2019-11-19 at 12 51 03 PM](https://user-images.githubusercontent.com/42977925/69180941-6fe2e100-0acb-11ea-81a7-78bc092f6722.png)

To this:
![Screen Shot 2019-11-19 at 12 53 25 PM](https://user-images.githubusercontent.com/42977925/69181047-a15bac80-0acb-11ea-8e61-be19aa4c055c.png)
